### PR TITLE
Create prepare_input.sh

### DIFF
--- a/Slurm/prepare_input.sh
+++ b/Slurm/prepare_input.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#SBATCH -J prepare_input
+#SBATCH -q batch -p compute
+#SBATCH -N 1
+#SBATCH -n 10
+#SBATCH -t 00:30:00
+#SBATCH --mem=300GB
+
+module load singularity
+singularity exec -B/projects ~/Heritability/Singularity/mousegwas.sif \
+Rscript ~/Heritability/Code/prepare_input.R 


### PR DESCRIPTION
Added missing `prepare_input.sh` to the Slurm scripts. 
Please review and merge if looks okay.

Also, modify this line `CSV file: A CSV file containing the traits, Strain and MouseID as columns` in the README file to 
`CSV file: A CSV file containing the traits, Strain, Sex, Weight and MouseID as columns.` as without these columns (esp. Weight), the prepare_input.R script will through an error when writing covariates. 